### PR TITLE
Added macro to switch between spinlock and condition variable

### DIFF
--- a/src/objs/parallel/reusable_thread.h
+++ b/src/objs/parallel/reusable_thread.h
@@ -1,5 +1,7 @@
 #pragma once
 
+//#define REUSABLE_THREAD_SPINLOCK
+
 #include <thread>
 #include <mutex>
 #include <future>
@@ -13,6 +15,9 @@ namespace parallel {
 			volatile bool running;
 			volatile unsigned tasks_count;
 			std::mutex mutex;
+		#ifndef REUSABLE_THREAD_SPINLOCK
+			std::condition_variable notifier;
+		#endif
 			std::thread thread;
 			std::list<std::packaged_task<void()>> task_queue;
 


### PR DESCRIPTION
When the number of threads equals the number of cores, spinlocks provide better performance due to reduced communication overhead.

When the number of threads is greater then the number of cores, spinlocks will cause threads with no tasks to take CPU time while threads with pending tasks might starve.